### PR TITLE
correct context handling

### DIFF
--- a/backend/models.go
+++ b/backend/models.go
@@ -1,13 +1,9 @@
 package backend
 
-import(
-	"context"
-)
-
 type Test struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-	ctx  context.Context
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	EventHandler *EventHandler
 }
 
 type ChannelMessage struct {

--- a/backend/test.go
+++ b/backend/test.go
@@ -1,17 +1,10 @@
 package backend
 
-import(
+import (
 	"log"
-	"context"
 )
-
-var eh = NewEventHandler()
 
 func (t *Test) CreateTest() {
 	log.Println("Creating...")
-  	eh.EmitEvent("env_launched")
-}
-
-func (t *Test) startup(ctx context.Context) {
-	t.ctx = ctx
+	t.EventHandler.EmitEvent("env_launched")
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"context"
 	"embed"
+
+	"example.com/backend"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
-	"example.com/backend"
-	"context"
 )
 
 //go:embed all:frontend/dist
@@ -15,9 +16,9 @@ var assets embed.FS
 func main() {
 	// Create an instance of the app structure
 	app := NewApp()
-	test := &backend.Test{}
 
 	eventHandler := backend.NewEventHandler()
+	test := &backend.Test{EventHandler: eventHandler}
 
 	// Create application with options
 	err := wails.Run(&options.App{


### PR DESCRIPTION
This is just one way to fix your logic.

I am not sure why the `backend` needs to be a completely separate project inside the same repository.
That being said I am not sure it hurts anything necessarily just another `go.mod` to keep up to date though.

Basically the issue was that you were creating a brand new blank `*EventProcessor` inside the `test.go` file and that new one did not have a copy of the Wails context.
Alternatively you could have added the `test.Startup()` call to the `OnStartup` callback and captured the proper context there as well.


